### PR TITLE
Fix bug in remove() function of `data.adt.Queue`

### DIFF
--- a/components/data/adt/Queue.dn
+++ b/components/data/adt/Queue.dn
@@ -54,14 +54,13 @@ component provides Queue(Destructor, AdaptEvents) {
 					
 					lw.next = null
 					lw.prev = null
-					
+					length--
+
 					break
 					}
 				
 				lw = lw.next
 				}
-			
-			length --
 			}
 		}
 	


### PR DESCRIPTION
Function `remove()` in `data.adt.Queue` would decrement length even when no element was deleted. This is now fixed.